### PR TITLE
fix issue with sorting by two properties and simplify functions

### DIFF
--- a/.github/workflows/build.js.yml
+++ b/.github/workflows/build.js.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Build
+
+on:
+  push:
+    branches: [ "master", "develop" ]
+  pull_request:
+    branches: [ "master", "develop" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ Array
 
 ### removeArticlesFromBeginning(value)
 
-Removes a and the from the beginning of a string. Mainly used when sorting items.
+Removes a, an and the from the beginning of a string. Mainly used when sorting items.
 
 #### parameters
 
@@ -596,7 +596,7 @@ direction(string): the direction to sort (asc or desc)
 Array
 
 
-### sortObjectArrayByTwoProperties(objectArray, sortPropertyOne, sortPropertyTwo, direction)
+### sortObjectArrayByTwoProperties(objectArray, sortPropertyOne, sortPropertyTwo, directionOne, directionTwo)
 
 Sorts an array on the properties and direction that were passed to the function. May not be functioning correctly.
 
@@ -608,7 +608,9 @@ sortPropertyOne(string): the first property to be used to sort
 
 sortPropertyTwo(string): the second property to be used to sort
 
-direction(string): the direction to sort (asc or desc)
+directionOne(string): the direction to sort (asc or desc) for sortPropertyOne
+
+directionTwo(string): the direction to sort (asc or desc) for sortPropertyTwo
 
 #### return
 

--- a/index.js
+++ b/index.js
@@ -1087,16 +1087,22 @@ export const sortObjectArrayByProperty = (objectArray, sortProperty, direction) 
 
   if (isNonEmptyArray(sortedArray) === true) {
 
-    sortedArray.sort((a, b) => {
+    if (isEmpty(sortProperty) === false) {
 
-      let aProperty = typeof a[sortProperty] === "number" ? a[sortProperty] : removeArticlesFromBeginning(a[sortProperty]);
-      let bProperty = typeof b[sortProperty] === "number" ? b[sortProperty] : removeArticlesFromBeginning(b[sortProperty]);
+      // * https://typeofnan.dev/sort-array-objects-multiple-properties-javascript/ -- 01/07/2024 JH
 
-      if (aProperty < bProperty) return -1;
-      if (aProperty > bProperty) return 1;
-      return 0;
+      sortedArray.sort((a, b) => {
 
-    });
+        let aProperty = typeof a[sortProperty] === "number" ? a[sortProperty] : removeArticlesFromBeginning(a[sortProperty]);
+        let bProperty = typeof b[sortProperty] === "number" ? b[sortProperty] : removeArticlesFromBeginning(b[sortProperty]);
+
+        if (aProperty < bProperty) return -1;
+        if (aProperty > bProperty) return 1;
+        return 0;
+
+      });
+
+    };
 
   };
 
@@ -1111,15 +1117,23 @@ export const sortObjectArrayByProperty = (objectArray, sortProperty, direction) 
 };
 
 
-export const sortObjectArrayByTwoProperties = (objectArray, sortPropertyOne, sortPropertyTwo, direction) => {
+export const sortObjectArrayByTwoProperties = (objectArray, sortPropertyOne, sortPropertyTwo, directionOne, directionTwo) => {
 
   let sortedArray = [...objectArray];
 
   if (isNonEmptyArray(sortedArray) === true) {
 
-    sortedArray = sortObjectArrayByProperty(sortedArray, sortPropertyTwo, direction);
+    if (isEmpty(sortPropertyTwo) === false) {
 
-    sortedArray = sortObjectArrayByProperty(sortedArray, sortPropertyOne, direction);
+      sortedArray = sortObjectArrayByProperty(sortedArray, sortPropertyTwo, directionOne);
+
+    };
+
+    if (isEmpty(sortPropertyOne) === false) {
+
+      sortedArray = sortObjectArrayByProperty(sortedArray, sortPropertyOne, directionTwo);
+
+    };
 
   };
 

--- a/index.js
+++ b/index.js
@@ -1083,49 +1083,20 @@ export const compareItemsForSorting = (itemOne, itemTwo) => {
 
 export const sortObjectArrayByProperty = (objectArray, sortProperty, direction) => {
 
-  // * https://flaviocopes.com/how-to-sort-array-of-objects-by-property-javascript/ -- 05/07/2022 MF
-  // * https://stackoverflow.com/questions/6913512/how-to-sort-an-array-of-objects-by-multiple-fields -- 03/06/2021 MF
-
   let sortedArray = [...objectArray];
 
   if (isNonEmptyArray(sortedArray) === true) {
 
-    if (typeof sortedArray[0][sortProperty] === "number") {
+    sortedArray.sort((a, b) => {
 
-      sortedArray.sort((a, b) => a[sortProperty] - b[sortProperty]);
+      let aProperty = typeof a[sortProperty] === "number" ? a[sortProperty] : removeArticlesFromBeginning(a[sortProperty]);
+      let bProperty = typeof b[sortProperty] === "number" ? b[sortProperty] : removeArticlesFromBeginning(b[sortProperty]);
 
-    } else {
+      if (aProperty < bProperty) return -1;
+      if (aProperty > bProperty) return 1;
+      return 0;
 
-      // * sortedArray.sort((a, b) => (removeArticlesFromBeginning(a[sortProperty]) > removeArticlesFromBeginning(b[sortProperty])) ? 1 : -1);
-      sortedArray.sort((a, b) => {
-
-        let aProperty = removeArticlesFromBeginning(a[sortProperty]);
-        let bProperty = removeArticlesFromBeginning(b[sortProperty]);
-
-        // * Put null values at the end of the array: https://stackoverflow.com/a/29829361 -- 11/30/2023 JH
-        if (aProperty === bProperty) {
-
-          return 0;
-
-        };
-
-        if (isEmpty(aProperty) === true) {
-
-          return 1;
-
-        };
-
-        if (isEmpty(bProperty) === true) {
-
-          return -1;
-
-        };
-
-        return aProperty > bProperty ? 1 : -1;
-
-      });
-
-    };
+    });
 
   };
 
@@ -1142,50 +1113,13 @@ export const sortObjectArrayByProperty = (objectArray, sortProperty, direction) 
 
 export const sortObjectArrayByTwoProperties = (objectArray, sortPropertyOne, sortPropertyTwo, direction) => {
 
-  // ? TODO: The sorting for two object properties isn't working correctly? -- 06/16/2022 MF
-  // * https://flaviocopes.com/how-to-sort-array-of-objects-by-property-javascript/ -- 05/07/2022 MF
-  // * https://stackoverflow.com/questions/6913512/how-to-sort-an-array-of-objects-by-multiple-fields -- 03/06/2021 MF
-
   let sortedArray = [...objectArray];
 
   if (isNonEmptyArray(sortedArray) === true) {
 
-    if (isEmpty(sortPropertyTwo) === false) {
+    sortedArray = sortObjectArrayByProperty(sortedArray, sortPropertyTwo, direction);
 
-      sortedArray.sort(
-        function (a, b) {
-
-          if (a[sortPropertyOne] === b[sortPropertyOne]) {
-
-            // * sortPropertyTwo is only important when a and b sortPropertyOne are the same -- 03/06/2021 MF
-            return compareItemsForSorting(a[sortPropertyTwo], b[sortPropertyTwo]);
-
-          };
-
-          return compareItemsForSorting(a[sortPropertyOne], b[sortPropertyOne]) ? 1 : -1;
-
-        });
-
-    } else if (isEmpty(sortPropertyOne) === false) {
-
-      // sortedArray.sort((a, b) => (a[sortPropertyOne] > b[sortPropertyOne]) ? 1 : -1);
-
-      sortedArray.sort(
-        function (a, b) {
-
-          return compareItemsForSorting(a[sortPropertyOne], b[sortPropertyOne]) ? 1 : -1;
-
-        }
-
-      );
-
-    };
-
-  };
-
-  if (formatLowerCase(direction) === "desc") {
-
-    sortedArray.reverse();
+    sortedArray = sortObjectArrayByProperty(sortedArray, sortPropertyOne, direction);
 
   };
 

--- a/index.js
+++ b/index.js
@@ -1057,7 +1057,7 @@ export const removeArticlesFromBeginning = (value) => {
 
   if (isEmpty(value) === false) {
 
-    newValue = formatLowerCase(newValue).replace(/^(a\.)/, "").replace(/^(the\.)/, "");
+    newValue = formatLowerCase(newValue).replace(/^(a\.)/, "").replace(/^(an\.)/, "").replace(/^(the\.)/, "");
 
   };
 
@@ -1089,7 +1089,7 @@ export const sortObjectArrayByProperty = (objectArray, sortProperty, direction) 
 
     if (isEmpty(sortProperty) === false) {
 
-      // * https://typeofnan.dev/sort-array-objects-multiple-properties-javascript/ -- 01/07/2024 JH
+      // * https://typeofnan.dev/sort-array-objects-multiple-properties-javascript/ -- 01/07/2025 JH
 
       sortedArray.sort((a, b) => {
 
@@ -1097,7 +1097,9 @@ export const sortObjectArrayByProperty = (objectArray, sortProperty, direction) 
         let bProperty = typeof b[sortProperty] === "number" ? b[sortProperty] : removeArticlesFromBeginning(b[sortProperty]);
 
         if (aProperty < bProperty) return -1;
+
         if (aProperty > bProperty) return 1;
+
         return 0;
 
       });
@@ -1125,13 +1127,13 @@ export const sortObjectArrayByTwoProperties = (objectArray, sortPropertyOne, sor
 
     if (isEmpty(sortPropertyTwo) === false) {
 
-      sortedArray = sortObjectArrayByProperty(sortedArray, sortPropertyTwo, directionOne);
+      sortedArray = sortObjectArrayByProperty(sortedArray, sortPropertyTwo, directionTwo);
 
     };
 
     if (isEmpty(sortPropertyOne) === false) {
 
-      sortedArray = sortObjectArrayByProperty(sortedArray, sortPropertyOne, directionTwo);
+      sortedArray = sortObjectArrayByProperty(sortedArray, sortPropertyOne, directionOne);
 
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shared-functions",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shared-functions",
-      "version": "0.2.3",
+      "version": "0.2.6",
       "dependencies": {
         "html-react-parser": "^5.1.10"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared-functions",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Contains common functions that could apply to all applications developed.",
   "author": "Orbis Education",
   "copyrightYear": "2025",


### PR DESCRIPTION
There was an issue with the sortObjectArrayByTwoProperties function. 

On line 1165 of the old code, 
`return compareItemsForSorting(a[sortPropertyOne], b[sortPropertyOne]) ? 1 : -1;`
should be:
`return compareItemsForSorting(a[sortPropertyOne], b[sortPropertyOne]);`

However, Ezri, Josh, and I all worked together to simplify the code. The sortObjectArrayByProperty function has been simplified, and then the sortObjectArrayByTwoProperties function just uses sortObjectArrayByProperty to sort both properties.

You can check the web dev chat to see how we arrived where we did.

The only thing that might be considered missing is that I removed the `isEmpty(sortPropertyTwo) === false` check. If there's some scenario where you think we might need it still, I would add it back before line 1120 of the new code.